### PR TITLE
metaタグのテストの Symfony4.4 対応

### DIFF
--- a/tests/Eccube/Tests/Web/TopControllerTest.php
+++ b/tests/Eccube/Tests/Web/TopControllerTest.php
@@ -13,9 +13,10 @@
 
 namespace Eccube\Tests\Web;
 
+use Eccube\Entity\BaseInfo;
+use Eccube\Entity\Page;
 use Eccube\Repository\BaseInfoRepository;
 use Eccube\Repository\PageRepository;
-use Symfony\Component\Routing\Generator\UrlGeneratorInterface;
 
 class TopControllerTest extends AbstractWebTestCase
 {
@@ -39,11 +40,15 @@ class TopControllerTest extends AbstractWebTestCase
     {
         // description を設定
         $description = 'あのイーハトーヴォのすきとおった風、夏でも底に冷たさをもつ青いそら、うつくしい森で飾られたモリーオ市、郊外のぎらぎらひかる草の波。';
-        $page = $this->container->get(PageRepository::class)->getByUrl('homepage');
+        /** @var PageRepository $pageRepository */
+        $pageRepository = $this->entityManager->getRepository(Page::class);
+        $page = $pageRepository->getByUrl('homepage');
         $page->setDescription($description);
         $this->entityManager->flush();
 
-        $shopName = $this->container->get(BaseInfoRepository::class)->get()->getShopName();
+        /** @var BaseInfoRepository $baseInfoRepository */
+        $baseInfoRepository = $this->entityManager->getRepository(BaseInfo::class);
+        $shopName = $baseInfoRepository->get()->getShopName();
         $expected_desc = mb_substr($description, 0, 120, 'utf-8');
 
         $crawler = $this->client->request('GET', $this->generateUrl('homepage'));


### PR DESCRIPTION
<!-- 以下を参考にコメントを作成してください。 -->

## 概要(Overview・Refs Issue)
<!-- PullRequestの目的、関連するIssue番号など -->

Symfony 4.4 では `$this->container->get()` でリポジトリが取得できなくなるので先んじて対応しておきました。

refs https://github.com/EC-CUBE/ec-cube/pull/4987

## 方針(Policy)
<!-- このPullRequestを作るにあたって考慮したものや除外した内容
  - 例）Symfony のXXにならって作成、3系で同様の仕様があったため など -->

## 実装に関する補足(Appendix)
<!-- コードだけではわかりづらい点など、実装するにあたってレビューアに追加で伝えておきたいこと -->

## テスト（Test)
<!-- テストを行っている範囲など、レビューアが安心できるような情報 -->

## 相談（Discussion）
<!-- 相談したいことや意見を求めたいこと -->

## マイナーバージョン互換性保持のための制限事項チェックリスト
<!-- マイナーバージョンでは、機能・プラグイン・デザインテンプレート互換性を損なう変更は原則取り込みません。 -->

- [ ] 既存機能の仕様変更
- [ ] フックポイントの呼び出しタイミングの変更
- [ ] フックポイントのパラメータの削除・データ型の変更
- [ ] twigファイルに渡しているパラメータの削除・データ型の変更
- [ ] Serviceクラスの公開関数の、引数の削除・データ型の変更
- [ ] 入出力ファイル(CSVなど)のフォーマット変更

## レビュワー確認項目

- [ ] 動作確認
- [ ] コードレビュー
- [ ] E2E/Unit テスト確認(テストの追加・変更が必要かどうか)
- [ ] 互換性が保持されているか
- [ ] セキュリティ上の問題がないか
